### PR TITLE
Raise exception if Active Storage is configured and `config.active_storage.service` not explicitly set

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -138,6 +138,8 @@ module ActiveStorage
 
         if config_choice = Rails.configuration.active_storage.service
           ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch(config_choice)
+        else
+          raise("Specify Active Storage service name by adding config.active_storage.service to config/environments/#{Rails.env}.rb.")
         end
       end
     end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

If `config.active_storage.service` has not been explicitly set in the respective environment's configuration file, then trying to use active storage throws a cryptic error message, which makes it harder to debug. This was the following error I had gotten:

```
Failed to replace attachments_attachments because one or more of the new records could not be saved.
```

Turned out I had forgotten to explicitly specify `config.active_storage.service` in my configuration file. Specifying it resolved the issue.

I had spent a considerable amount of time trying to debug this, and I would have immediately known what the fix was if the error message had been clearer. So, I'm turning in this PR so that anyone facing this in the future will know what to do at a quick glance.

Thanks!
### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
